### PR TITLE
Fixed typo in help information

### DIFF
--- a/eval/opp_sca2csv.pl
+++ b/eval/opp_sca2csv.pl
@@ -442,7 +442,7 @@ opp_sca2csv.pl [options] [file ...]
 
 	Output this information
 
-e.g.: opp_sca2csv.pl -M '".'^scenario\.host\[(?<module>[0-9]+)\]'."' -f totalRcvd -f totalSent input.sca >output.csv
+e.g.: opp_sca2csv.pl -M '".'^scenario\.host\[(?<module>[0-9]+)\]'."' -F totalRcvd -F totalSent input.sca >output.csv
 
 =cut
 


### PR DESCRIPTION
The "help information" output provides an example at the very end. Here, the filter option is specified with a lowercase f, which is wrong, since it must be an uppercase F. 

The filter option (with uppercase F) is correctly provided in the help text. Only the example at the end is wrong.