### PR TITLE
Prepare opp_vec2longcsv.sh for OMNeT++

### DIFF
--- a/eval/opp_vec2longcsv.sh
+++ b/eval/opp_vec2longcsv.sh
@@ -26,7 +26,7 @@
 set -e
 
 function extract_data_records() {
-    grep -v '^vector\|attr\|version\|param\|run\|itervar' | grep -v '^$' | sort -s -k 1n,1 -k 2n,2 --buffer-size=5%
+    grep -v '^vector\|attr\|version\|param\|run\|itervar\|config' | grep -v '^$' | sort -s -k 1n,1 -k 2n,2 --buffer-size=5%
 }
 
 function extract_vector_definitions() {

--- a/eval/opp_vec2longcsv.sh
+++ b/eval/opp_vec2longcsv.sh
@@ -30,7 +30,7 @@ function extract_data_records() {
 }
 
 function extract_vector_definitions() {
-    grep '^vector' $TMPDIR/vec.fifo | sort -s -k 2n | sed 's/vector[[:space:]]\{1,\}\([0-9]\{1,\}\)[[:space:]]\{1,\}\([^[:space:]]\{1,\}\)[[:space:]]\{1,\}\([^[:space:]]\{1,\}\)[[:space:]]\{1,\}[ETV]*/\1	\2	\3/'
+    grep '^vector' | sort -s -k 2n | sed 's/vector[[:space:]]\{1,\}\([0-9]\{1,\}\)[[:space:]]\{1,\}\([^[:space:]]\{1,\}\)[[:space:]]\{1,\}\([^[:space:]]\{1,\}\)[[:space:]]\{1,\}[ETV]*/\1	\2	\3/'
 }
 
 FNAME="$1"
@@ -48,4 +48,4 @@ mkfifo $TMPDIR/vec.fifo
 # - extract the data records from one of the input streams
 # - extract the vector definitions from the duplicated output stream (the named pipe)
 # - join both together to create a csv file
-cat $FNAME | tee $TMPDIR/vec.fifo | extract_data_records | join -j1 <(extract_vector_definitions) -
+cat $FNAME | tee $TMPDIR/vec.fifo | extract_data_records | join -j1 <(cat $TMPDIR/vec.fifo | extract_vector_definitions) -


### PR DESCRIPTION
OMNeT++ 6 changes its vector file format such that the existing `opp_vec2longcsv.sh` script will fail with an error:

> join: input is not in sorted order

This PR adapts the script accordingly (and contains an unrelated commit that makes the used functions more functional).